### PR TITLE
Update golem.Rmd

### DIFF
--- a/golem.Rmd
+++ b/golem.Rmd
@@ -12,8 +12,7 @@ The stable release can be found on CRAN, and installed with:
 install.packages("golem")
 ```
 
-
-`{golem}` can only be found on GitHub so you have to install it with:
+A more up to date (but maybe less stable) version of `{golem}` can also be found on GitHub that you can install with:
 
 ```{r eval = FALSE}
 remotes::install_github("Thinkr-open/golem")


### PR DESCRIPTION
Golem is now on CRAN and not only on github! Congrats :)

This PR aims to correct the installation process were it is stated that golem is only available through remote installation.