### PR TITLE
Make grammar and typo changes in big-shiny chapter

### DIFF
--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -27,14 +27,14 @@ Getting a clear definition is not an easy task
 ^[Ironic right?]
  as it very depends on who is concerned and who you're talking to.
 But let's try to come with a definition that will serve us in the context of engineering Shiny applications. 
-When building sofwares, we can think of complexity from two points of view: the complexity as it is seen by the coder, and the complexity as it is seen by the customer / end user
+When building software, we can think of complexity from two points of view: the complexity as it is seen by the coder, and the complexity as it is seen by the customer / end user
 ^[from _The Art of Unix Programming_, "Chapter 13: Speaking of Complexity"].
 
 #### Two views of complexity
 
 + From the developer point of view
 
-An app is to be considered complex when it is big enough in term of size and functionalities so that it makes it impossible to reason about it at once, and you need to rely on tools to understand and handle this complexity.
+An app is to be considered complex when it is big enough in terms of size and functionality that it makes it impossible to reason about it at once, and you must rely on tools to understand and handle this complexity.
 This type of complexity is called _implementation complexity_. 
 One of the goal of this book is to present you a methodology and toolkit that will help you reduce this form of complexity. 
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -36,24 +36,24 @@ When building sofwares, we can think of complexity from two points of view: the 
 
 An app is to be considered complex when it is big enough in term of size and functionalities so that it makes it impossible to reason about it at once, and you need to rely on tools to understand and handle this complexity.
 This type of complexity is called _implementation complexity_. 
-One of the goal of this book is to present you a methodology and toolings that will help you reduce this form of complexity. 
+One of the goal of this book is to present you a methodology and toolbox that will help you reduce this form of complexity. 
 
 For example, we'll talk about a design / prototype / build / secure / deploy, which helps you reduce the complexity of implementing and maintain new app features. 
 We'll also be talking at length about the `{golem}` package, which provides a toolkit for reducing the cognitive load of handling complexity in large Shiny applications. 
-For example, creatign a new Shiny module requires following a very strict structure. 
+For example, creating a new Shiny module requires following a very strict structure. 
 One way to do that is to remember how to do that and to code it from scratch (a method which has an important cognitive load and is very error prone). 
 Another way is to copy and paste an existing module and to adapt it, which is, as any copy and paste, likely to lead to errors. 
 Or there is the `{golem}` way, in which you rely on a robust tool to build the foundations for a new module.
 
-Another benefit of adopting automation for common application component is that it allows to be sure that you're following a convention. 
-And conventions are crucial when it comes to building and maintaining complex system: by imposing a formalized structure for a piece of code, it ehances readability, lessens the learning curve, and lightens the chance for typo and/or copy and paste error. 
+Another benefit of adopting automation for common application component is that it ensures that you're following a convention. 
+And conventions are crucial when it comes to building and maintaining complex systems: by imposing a formalized structure for a piece of code, it ehances readability, lessens the learning curve, and lightens the chance for typos and/or copy and paste errors. 
 
 
 +  Customers and users
 
-On the other hand, customers and end user see complexity as _interface complexity_. 
+On the other hand, customers and end users see complexity as _interface complexity_. 
 Interface complexity can be driven by a lot of elements, for example the probability of making an error while using the app, the difficulty to understand the logical progression in the the app, the presence of unfamiliar behaviour or terms, visual distractions...
-This book will also bring you strategy to help you cope with the need for simplification when it comes to designin interface. 
+This book will also bring you strategy to help you cope with the need for simplification when it comes to designing interface. 
 
 #### Balancing complexities
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -162,17 +162,17 @@ This is what this book is about: how to organise your Shiny App in a way that is
 
 ## What's a successful Shiny App? 
 
-Another good news is that your application does not have to be complex to be successful.
+The good news is that your application does not have to be complex to be successful.
 Even more, in a world where "less is more", the more you can reduce your application complexity, the more you'll be prepared for success. 
 
 So what's a successful Shiny app? 
-Defining such a metric is not that easy a task, but we can extract some common patterns when it comes to applications that can be listed as successful. 
+Defining such a metric is not an easy a task, but we can extract some common patterns when it comes to applications that would be considered successful. 
 
 ### It exists
 
 First of all, an app is successful if it was delivered.
 In other words, the developer team was able to move from specification to implementation to testing to delivering. 
-This is a very engineering-oriented definition of success, but that's a pragmatic one: an app that never reaches the state of usability is not a successful app, as something along the way has blocked the process of finishing the code. 
+This is a very engineering-oriented definition of success, but it's a pragmatic one: an app that never reaches the state of usability is not a successful app, as something along the way has blocked the process of finishing the code. 
 
 This implies a lot of things: but mostly it implies that the team was able to organise itself in an efficient way, so that they were able to work together in making the project a success. 
 And anybody that has already worked on a code base as a team knows it's not an easy task.
@@ -180,22 +180,22 @@ And anybody that has already worked on a code base as a team knows it's not an e
 ### It's accurate
 
 The app was delivered, and it answers the question it is supposed to answer, or serves the purpose it is supposed to serve. 
-Delivering is not the only thing to keep in mind: you can deliver a working app but it doesn't work in the way it is supposed to work.
+Delivering is not the only thing to keep in mind: you can deliver a working app but it might not work in the way it is supposed to work.
 
 Just as before, accuracy means that between the moment the idea appears in someone's mind and the moment the app is actually ready to be used, everybody was able to work together toward a common goal.
 
 ### It's usable
 
-The app was delivered, it answers the question it is supposed to answer, and it is friendly on the user. 
-Unless you're coding for the sake of the art, there will always be one or more end user(s). 
-And if these person can't use the app because it's too hard to use, too hard to understand, because it's too slow or there is no inherent logic in the way the user experience is designed, then it's hard to tell the app is a success. 
+The app was delivered, it answers the question it is supposed to answer, and it is user-friendly. 
+Unless you're coding for the sake of the art, there will always be one or more end users. 
+And if these people can't use the app because it's too hard to use, too hard to understand, because it's too slow or there is no inherent logic in how the user experience is designed, then it's innapropriate to call the app is a success. 
 
 ### It's immortal
 
 Of course that's a little bit far fetched, but when designing the app, you should set the ground for robustness in time and aim at a (theoretical) immortality of the app. 
 
 Planning for the future is a very important component of a successful Shiny App project.
-Once the app is out, it's successful if it can exist in the long run, with all the hazards that implies: new package versions that potentially break the code base, implementation of new features in the global interface, changing key features of the UI or the back-end, and not to mention passing the code base along to someone who has not worked on the first version, and who is now in charge of working on version 2. 
-And this, again, is hard to do without effective planning and efficient tooling. 
-Well, and this new person might simply be you, a month from now. 
+Once the app is out, it's successful if it can exist in the long run, with all the hazards that implies: new package versions that potentially break the code base, implementation of new features in the global interface, changing key features of the UI or the back-end, and not to mention passing the code base along to someone who has not worked on the first version, and who is now in charge of developing the next version. 
+And this, again, is hard to do without effective planning and efficient engineering. 
+In fact, this new person might simply be you, a month from now. 
 And _"You'll be there in the future too, maintaining code you may have half forgotten under the press of more recent projects. When you design for the future, the sanity you save may be your own._^[_The Art of Unix Programming_, Eric Steven Raymond]

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -36,24 +36,24 @@ When building sofwares, we can think of complexity from two points of view: the 
 
 An app is to be considered complex when it is big enough in term of size and functionalities so that it makes it impossible to reason about it at once, and you need to rely on tools to understand and handle this complexity.
 This type of complexity is called _implementation complexity_. 
-One of the goal of this book is to present you a methodology and toolbox that will help you reduce this form of complexity. 
+One of the goal of this book is to present you a methodology and toolkit that will help you reduce this form of complexity. 
 
-For example, we'll talk about a design / prototype / build / secure / deploy, which helps you reduce the complexity of implementing and maintain new app features. 
+For example, we'll talk about a design / prototype / build / secure / deploy framework, which helps you reduce the complexity of implementing and maintaining new app features. 
 We'll also be talking at length about the `{golem}` package, which provides a toolkit for reducing the cognitive load of handling complexity in large Shiny applications. 
 For example, creating a new Shiny module requires following a very strict structure. 
 One way to do that is to remember how to do that and to code it from scratch (a method which has an important cognitive load and is very error prone). 
 Another way is to copy and paste an existing module and to adapt it, which is, as any copy and paste, likely to lead to errors. 
 Or there is the `{golem}` way, in which you rely on a robust tool to build the foundations for a new module.
 
-Another benefit of adopting automation for common application component is that it ensures that you're following a convention. 
+Another benefit of adopting automation for common application components is that it ensures that you're following a convention. 
 And conventions are crucial when it comes to building and maintaining complex systems: by imposing a formalized structure for a piece of code, it ehances readability, lessens the learning curve, and lightens the chance for typos and/or copy and paste errors. 
 
 
 +  Customers and users
 
 On the other hand, customers and end users see complexity as _interface complexity_. 
-Interface complexity can be driven by a lot of elements, for example the probability of making an error while using the app, the difficulty to understand the logical progression in the the app, the presence of unfamiliar behaviour or terms, visual distractions...
-This book will also bring you strategy to help you cope with the need for simplification when it comes to designing interface. 
+Interface complexity can be driven by a lot of elements. For example, the probability of making an error while using the app, difficulty understanding the logical progression in the the app, the presence of unfamiliar behaviour or terms, visual distractions...
+This book will give you a strategy to help you cope with the need for simplification when it comes to designing user interfaces. 
 
 #### Balancing complexities
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -130,7 +130,7 @@ cloc_cran("attempt", .progress = FALSE)
 
 ### With great complexity comes great responsibility
 
-When your program reaches this state, there is a lot of potential for failure, be it from a developer or user perspective. For the code, bugs are harder to anticipate: it's hard to think about all the different paths the software can follow, it's hard to detect bugs because they are deeply nested in the numerous routines the app is doing. 
+When your program reaches this state, there is a lot of potential for failure, be it from a developer or user perspective. For the code, bugs are harder to anticipate: it's hard to think about all the different paths the software can follow and difficult to detect bugs because they are deeply nested in the numerous routines the app is doing. 
 It's also hard to think about what the state of your app is at a given moment in time because of the numerous inputs and outputs your app contains. 
 From the user perspective, the more complex an app, the more steep the learning curve is, which means that the user will have to invest more time learning how the app works, and will be even more disappointed if ever they realise this time has been a waste. 
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -81,8 +81,8 @@ _-> Insert here something of the like: "It's up to you to think about what's the
 
 #### Assessing complexity
 
-Another measure that sometime comes in the discussion is the codebase size. 
-It's relatively hard to use this number of lines metric, as R is very permissive when it comes to identation and line break. It also depends on your coding style and the packages you're using. For example, tidyverse packages encourage the use of the pipe (`%>%`)
+Another measure that sometimes comes in the discussion is the codebase size. 
+It's relatively hard to use this number of lines metric, as R is very permissive when it comes to identation and line breaks. It also depends on your coding style and the packages you're using. For example, tidyverse packages encourage the use of the pipe (`%>%`)
 ^[] 
 with one function by line, producing more lines in the end code.
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -100,9 +100,14 @@ iris[
   ]
 ```
 
-9 lines of code for something that should also be written in one, three, five...
+9 lines of code for something that could also be written in one line.  
 
-Another drawback of this metric is that it focuses on numbers instead of readability, and on the long run yes, readability matters
+```{r}
+iris[1:5, c("Species")]
+```
+
+
+Another drawback of this metric is that it focuses on numbers instead of readability, and in the long run, yes, readability matters
 ^["Pressure to keep the codebase size down by using extremely dense and complicated implementation techniques can cause a cascade of implementation complexity in the system, leading to an un-debuggable mess.", from _The Art of Unix Programming_, "Chapter 13: Speaking of Complexity"]. 
 
 // TODO

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -57,25 +57,25 @@ This book will give you a strategy to help you cope with the need for simplifica
 
 #### Balancing complexities
 
-There is an inherent tension between these two source of complexity, as designing an app means finding a good balance between implementation ann interface complexity. 
+There is an inherent tension between these two types of complexity. Designing an app means finding a good balance between implementation and interface complexity. 
 Reducing implementation complexity means one has to make some decisions that will lower one while rising the other. 
 
 For example, we can think of something very common in Shiny: the "too much reactivity" pattern. 
-In some cases, coders try to make everything reactive: e.g., three sliders and a selectInput, all updating a plot.
+In some cases, coders try to make everything reactive: e.g., three sliders and a selectInput, all updating a single plot.
 This behaviour lowers the interface complexity: users don't have to think a lot about what they are doing, they just move things around and it updates. 
-But this kind of pattern can make the app computing too much things: user rarely go to the slider value they need from the first shoot, and usually miss what they want to select in an input. 
+But this kind of pattern can make the app compute too many things: users rarely go to the slider value they need on their first try. They usually miss what they actually want to select in an input. 
 So, way more computation for R. 
-One solution can be to delay reactivity or to cache things so that R computes less things. 
-But that comes with a cost: handling delayed reactivity and caching elements, which increases implementation complexity. 
+One solution can be to delay reactivity or to cache things so that R computes fewer things. 
+But that comes with a cost: handling delayed reactivity and caching elements increases implementation complexity. 
 One other solution is simply to add a button after the input, and only update the plot when the user clicks on it. 
 This pattern makes it easier to control reactivity from an implementation side. 
-But it can make the interface a little bit more complex for the user who have to perform another action. 
+But it can make the interface a little bit more complex for the user who have to perform another action in addition to changing their inputs.  
 
-We'll argue somewhere else in the book that on the other hand, not enough reactivity is better than too much reactivity, as the latter increases computation time, and relies on the assumption that the user makes the right action on the first try.
-Another good example is `{shiny}`'s `dateRangeInput()` function being able to take a start which is posterior to the end (which is the behaviour of the JavaScript plugin used in `{shiny}` to create this input). 
+We'll argue somewhere else in the book that not enough reactivity is better than too much reactivity, as the latter increases computation time, and relies on the assumption that the user makes the right action on the first try.
+Another good example is `{shiny}`'s `dateRangeInput()` function, which takes a start which is posterior to the end (which is the behaviour of the JavaScript plugin used in `{shiny}` to create this input). 
 Handling this special case is doable: with a little bit of craft, you can watch what the user inputs and throw an error if the start is after the end
 ^[see [shiny/issues/2043#issuecomment-525640738](https://github.com/rstudio/shiny/issues/2043#issuecomment-525640738) for an example].
-That solution augments the implementation complexity, while leaving it as is requires the user to think about wether or not the starting date is before the ending date, thus increasing the interface complexity.
+That solution augments the implementation complexity, while leaving it as is requires the user to think about whether or not the starting date is before the ending date, thus increasing the interface complexity.
 
 _-> Insert here something of the like: "It's up to you to think about what's the best balance between these two sources." _
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -137,29 +137,28 @@ From the user perspective, the more complex an app, the more steep the learning 
 ### Production Grade Software Engineering
 
 Complexity is still frowned upon by a lot of developers, notably because it has been seen as something to avoid according to the Unix philosophy. 
-But there are dozens of reasons why an app can become complex: for example, the question your app is answering to is quite a complicated question which involves a lot of computation and routines, the app is rather ambitious and implements a lot of features, etc.
+But there are dozens of reasons why an app can become complex: for example, the question your app is answering is quite complicated and involves a lot of computation and routines. The resulting app is rather ambitious and implements a lot of features, etc.
 So yes, there is a chance that if you're reading this page, you're working or are planning to work on a complex Shiny app. 
-And this is not necessarily a bad thing. 
-Shiny apps can definitely be used to implement a production-grade
+And this is not necessarily a bad thing! 
+Shiny apps can definitely be used to implement production-grade
 ^[By production-grade, we mean a software that can be used in a context where people use it for doing their job, and where failures or bugs have real-life consequences] 
 software, but production-grade software implies production-grade software engineering. 
-And your goal to make this project a success is be to prepared, to use tools that will reduce the complexity of your app, and ensure that your app has the quality to age well. 
+To make your project a success, you need to use tools that reduce the complexity of your app and ensure that your app is resiliant to aging. 
 
-In other words, production-grade Shiny apps require working with a software engineering mindset. 
-Which is not always that easy a task in the R world. 
-R comes from the land of the academics and is still used a lot as an "experimentation tool", and in context where production quality is one of the least concerns. 
+In other words, production-grade Shiny apps require working with a software engineering mindset, which is not always an easy task in the R world. 
+R comes from the land of the academics and is still used as an "experimentation tool", where production quality is one of the least concerns. 
 Many developers in the R world have learned R as a tool for making statistics, not as a tool for building software.
-Both these contexts are very different and require different mindsets, different skills and tools. 
+These contexts are very different and require different mindsets, skills, and tools. 
 
 With `{shiny}`, as we said before, it's quite easy to prototype a simple app, without any "hardcore" software engineering skills. 
 And when we're happy with our little proof of concept, we're tempted to add something new. 
 And another. 
 And another. 
-And without any structured methodology, we're almost certain that we'll reach the cliff of complexity very soon, with a code base that is hardly (if ever) ready to be refactored to be sent to production. 
+And without any structured methodology, we're almost certain to reach the cliff of complexity very soon and end up with a code base that is hardly (if ever) ready to be refactored to be sent to production. 
 
 The good news is that building a complex app with R (or with any other language) is not an impossible task. 
-But it requires planning, rigor, and correct tooling. 
-This is what this book is about: how to organise your Shiny App project in a way that is time and code efficient, and how to get the correct tooling for making your application a success.
+But it requires planning, rigor, and correct engineering.   
+This is what this book is about: how to organise your Shiny App in a way that is time and code efficient, and how to use correct engineering to make your app a success.
 
 ## What's a successful Shiny App? 
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -128,12 +128,11 @@ cloc_cran("attempt", .progress = FALSE)
 
 -> https://github.com/MangoTheCat/cyclocomp 
 
-### With great complexity come great responsibilities
+### With great complexity comes great responsibility
 
-When your program reaches this state, there is a lot of potential for failure, be it from a developer perspective or from a user point of view. For the code, bugs are harder to anticipate: it's hard to think about all the different paths the software can follow, it's hard to detect bugs because they are deeply nested in the numerous routines the app is doing. 
+When your program reaches this state, there is a lot of potential for failure, be it from a developer or user perspective. For the code, bugs are harder to anticipate: it's hard to think about all the different paths the software can follow, it's hard to detect bugs because they are deeply nested in the numerous routines the app is doing. 
 It's also hard to think about what the state of your app is at a given moment in time because of the numerous inputs and outputs your app contains. 
-From the user perspective, the more complex an app, the more important the learning curve is. 
-Which means that the user will have to invest time learning how the app works, and will be even more disappointed if ever they realise this time has been a waste. 
+From the user perspective, the more complex an app, the more steep the learning curve is, which means that the user will have to invest more time learning how the app works, and will be even more disappointed if ever they realise this time has been a waste. 
 
 ### Production Grade Software Engineering
 

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -21,7 +21,7 @@ With small and simple Shiny apps, no knowledge of HTML, CSS or JavaScript is req
 
 Things are quite simple when it comes to small prototypes or proof of concepts. 
 But things change when your application reaches "the cliff of complexity"
-^[We borrow this term from Charity Major, as heard in _Test in Production with Charity Majors_, [CoRecursive](https://corecursive.com/019-test-in-production-with-charity-majors/)].
+^[We borrow this term from Charity Major, as heard in _Test in Production with Charity Majors_, [CoRecursive](https://corecursive.com/019-test-in-production-with-charity-majors/)]{target="_blank"}.
 But what do we mean by complexity? 
 Getting a clear definition is not an easy task
 ^[Ironic right?]
@@ -74,7 +74,7 @@ But it can make the interface a little bit more complex for the user who have to
 We'll argue somewhere else in the book that not enough reactivity is better than too much reactivity, as the latter increases computation time, and relies on the assumption that the user makes the right action on the first try.
 Another good example is `{shiny}`'s `dateRangeInput()` function, which takes a start which is posterior to the end (which is the behaviour of the JavaScript plugin used in `{shiny}` to create this input). 
 Handling this special case is doable: with a little bit of craft, you can watch what the user inputs and throw an error if the start is after the end
-^[see [shiny/issues/2043#issuecomment-525640738](https://github.com/rstudio/shiny/issues/2043#issuecomment-525640738) for an example].
+^[see [shiny/issues/2043#issuecomment-525640738](https://github.com/rstudio/shiny/issues/2043#issuecomment-525640738){target="_blank"} for an example].
 That solution augments the implementation complexity, while leaving it as is requires the user to think about whether or not the starting date is before the ending date, thus increasing the interface complexity.
 
 _-> Insert here something of the like: "It's up to you to think about what's the best balance between these two sources." _

--- a/big-shiny.Rmd
+++ b/big-shiny.Rmd
@@ -46,7 +46,7 @@ Another way is to copy and paste an existing module and to adapt it, which is, a
 Or there is the `{golem}` way, in which you rely on a robust tool to build the foundations for a new module.
 
 Another benefit of adopting automation for common application components is that it ensures that you're following a convention. 
-And conventions are crucial when it comes to building and maintaining complex systems: by imposing a formalized structure for a piece of code, it ehances readability, lessens the learning curve, and lightens the chance for typos and/or copy and paste errors. 
+And conventions are crucial when it comes to building and maintaining complex systems: by imposing a formalized structure for a piece of code, it enhances readability, lessens the learning curve, and lightens the chance for typos and/or copy and paste errors. 
 
 
 +  Customers and users
@@ -82,7 +82,7 @@ _-> Insert here something of the like: "It's up to you to think about what's the
 #### Assessing complexity
 
 Another measure that sometimes comes in the discussion is the codebase size. 
-It's relatively hard to use this number of lines metric, as R is very permissive when it comes to identation and line breaks. It also depends on your coding style and the packages you're using. For example, tidyverse packages encourage the use of the pipe (`%>%`)
+It's relatively hard to use this number of lines metric, as R is very permissive when it comes to indentation and line breaks. It also depends on your coding style and the packages you're using. For example, [`{tidyverse}`](https://www.tidyverse.org/){target="_blank"} packages encourage the use of the pipe (`%>%`)
 ^[] 
 with one function by line, producing more lines in the end code.
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -75,6 +75,8 @@ Feel free to [open an issue](https://github.com/ThinkR-open/building-shiny-apps-
 
 ## Acknowledgments {-}
 
++ [Liz Roten](https://github.com/eroten){target="_blank"}
+
 // TODO : 
 
 ```{r echo = FALSE}


### PR DESCRIPTION
This PR reviews chapter 1 and makes spelling, grammar, and sentence structure changes that make the text more understandable and easy to read. I added "{target='_blank'}" to chapter 1 links and  I added my name and GitHub account link to the Acknowledgments section in the introduction, as well. 

I'm a native English (American) speaker, so I hope these edits are useful. I'd also be happy to review text for active vs. passive voice. I'll open an issue for discussion. 

I, Elizabeth Roten, assign the copyright of this contribution to Colin Fay, Vincent Guyader, Cervan Girard and Sébastien Rochette. 